### PR TITLE
DES-13210: add --winhttp-proxy-resolver cmd line arg

### DIFF
--- a/minuet/Paragon.Runtime/ParagonRuntime.cs
+++ b/minuet/Paragon.Runtime/ParagonRuntime.cs
@@ -131,10 +131,11 @@ namespace Paragon.Runtime
 
                     var argArray = Environment.GetCommandLineArgs();
 
-
-               
                     List<string> appArgs = new List<string>();
                     appArgs.Add("--process-per-tab");
+
+                    // as per DES-13210, re-test when chromium 56 is available and see if we can remove this flag
+                    appArgs.Add("--winhttp-proxy-resolver");
 
                     // Pass through Kerberos and proxy parameters.
                     for (int i = 0; i < argArray.Length; i++)


### PR DESCRIPTION
add command line by default until issue is fixed in chromium 56.